### PR TITLE
Update cpu, ram and storage limits to match DataCenter nodes

### DIFF
--- a/documentation/models/ContainerResourceRequirements.md
+++ b/documentation/models/ContainerResourceRequirements.md
@@ -6,8 +6,8 @@ Specifies the resource requirements for a container.
 
 | Name           | Type      | Required | Description                                                                                                                          |
 | :------------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| cpu            | int       | ✅       | The number of CPU cores required by the container. Must be between 1 and 16.                                                         |
-| memory         | int       | ✅       | The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.                                        |
+| cpu            | int       | ✅       | The number of CPU cores required by the container. Must be between 1 and 1024.                                                       |
+| memory         | int       | ✅       | The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.                                   |
 | gpu_classes    | List[str] | ✅       | A list of GPU class UUIDs required by the container. Can be null if no GPU is required.                                              |
-| storage_amount | int       | ❌       | The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes). |
+| storage_amount | int       | ❌       | The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes). |
 | shm_size       | int       | ❌       | The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB.                                                  |

--- a/documentation/models/ContainerResourceUpdateSchema.md
+++ b/documentation/models/ContainerResourceUpdateSchema.md
@@ -6,8 +6,8 @@ Defines the resource specifications that can be modified for a container group, 
 
 | Name           | Type      | Required | Description                                                                                  |
 | :------------- | :-------- | :------- | :------------------------------------------------------------------------------------------- |
-| cpu            | int       | ❌       | The number of CPU cores to allocate to the container (between 1 and 16 cores).               |
-| memory         | int       | ❌       | The amount of memory to allocate to the container in megabytes (between 1024MB and 61440MB). |
+| cpu            | int       | ❌       | The number of CPU cores to allocate to the container (between 1 and 1024 cores).             |
+| memory         | int       | ❌       | The amount of memory to allocate to the container in megabytes (between 1024MB and 1073741824MB). |
 | gpu_classes    | List[str] | ❌       | List of GPU class identifiers that the container can use, specified as UUIDs.                |
-| storage_amount | int       | ❌       | The amount of storage to allocate to the container in bytes (between 1GB and 250GB).         |
+| storage_amount | int       | ❌       | The amount of storage to allocate to the container in bytes (between 1 GB and 1 PB (1125899906842624 bytes)). |
 | shm_size       | int       | ❌       | The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB.          |

--- a/documentation/models/CreateContainerResourceRequirements.md
+++ b/documentation/models/CreateContainerResourceRequirements.md
@@ -6,8 +6,8 @@ Specifies the resource requirements for creating a container.
 
 | Name           | Type      | Required | Description                                                                                                                          |
 | :------------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------------------------------- |
-| cpu            | int       | ✅       | The number of CPU cores required by the container. Must be between 1 and 16.                                                         |
-| memory         | int       | ✅       | The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.                                        |
+| cpu            | int       | ✅       | The number of CPU cores required by the container. Must be between 1 and 1024.                                                       |
+| memory         | int       | ✅       | The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.                                   |
 | gpu_classes    | List[str] | ❌       | A list of GPU class UUIDs required by the container. Can be null if no GPU is required.                                              |
-| storage_amount | int       | ❌       | The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes). |
+| storage_amount | int       | ❌       | The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes). |
 | shm_size       | int       | ❌       | The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB.                                                  |

--- a/src/salad_cloud_sdk/models/container_resource_requirements.py
+++ b/src/salad_cloud_sdk/models/container_resource_requirements.py
@@ -8,13 +8,13 @@ from .utils.sentinel import SENTINEL
 class ContainerResourceRequirements(BaseModel):
     """Specifies the resource requirements for a container.
 
-    :param cpu: The number of CPU cores required by the container. Must be between 1 and 16.
+    :param cpu: The number of CPU cores required by the container. Must be between 1 and 1024.
     :type cpu: int
-    :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.
+    :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.
     :type memory: int
     :param gpu_classes: A list of GPU class UUIDs required by the container. Can be null if no GPU is required.
     :type gpu_classes: List[str]
-    :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes)., defaults to None
+    :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes)., defaults to None
     :type storage_amount: int, optional
     :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
     :type shm_size: int, optional
@@ -31,23 +31,26 @@ class ContainerResourceRequirements(BaseModel):
     ):
         """Specifies the resource requirements for a container.
 
-        :param cpu: The number of CPU cores required by the container. Must be between 1 and 16.
+        :param cpu: The number of CPU cores required by the container. Must be between 1 and 1024.
         :type cpu: int
-        :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.
+        :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.
         :type memory: int
         :param gpu_classes: A list of GPU class UUIDs required by the container. Can be null if no GPU is required.
         :type gpu_classes: List[str]
-        :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes)., defaults to None
+        :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes)., defaults to None
         :type storage_amount: int, optional
         :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
         :type shm_size: int, optional
         """
-        self.cpu = self._define_number("cpu", cpu, ge=1, le=16)
-        self.memory = self._define_number("memory", memory, ge=1024, le=61440)
+        self.cpu = self._define_number("cpu", cpu, ge=1, le=1024)
+        self.memory = self._define_number("memory", memory, ge=1024, le=1073741824)
         self.gpu_classes = gpu_classes
         if storage_amount is not SENTINEL:
             self.storage_amount = self._define_number(
-                "storage_amount", storage_amount, ge=1073741824, le=268435456000
+                "storage_amount",
+                storage_amount,
+                ge=1073741824,
+                le=1125899906842624,
             )
         if shm_size is not SENTINEL:
             self.shm_size = self._define_number(

--- a/src/salad_cloud_sdk/models/container_resource_update_schema.py
+++ b/src/salad_cloud_sdk/models/container_resource_update_schema.py
@@ -9,13 +9,13 @@ from .utils.sentinel import SENTINEL
 class ContainerResourceUpdateSchema(BaseModel):
     """Defines the resource specifications that can be modified for a container group, including CPU, memory, GPU classes, and storage allocations.
 
-    :param cpu: The number of CPU cores to allocate to the container (between 1 and 16 cores)., defaults to None
+    :param cpu: The number of CPU cores to allocate to the container (between 1 and 1024 cores)., defaults to None
     :type cpu: int, optional
-    :param memory: The amount of memory to allocate to the container in megabytes (between 1024MB and 61440MB)., defaults to None
+    :param memory: The amount of memory to allocate to the container in megabytes (between 1024MB and 1073741824MB)., defaults to None
     :type memory: int, optional
     :param gpu_classes: List of GPU class identifiers that the container can use, specified as UUIDs., defaults to None
     :type gpu_classes: List[str], optional
-    :param storage_amount: The amount of storage to allocate to the container in bytes (between 1GB and 250GB)., defaults to None
+    :param storage_amount: The amount of storage to allocate to the container in bytes (between 1 GB and 1 PB (1125899906842624 bytes))., defaults to None
     :type storage_amount: int, optional
     :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
     :type shm_size: int, optional
@@ -32,22 +32,22 @@ class ContainerResourceUpdateSchema(BaseModel):
     ):
         """Defines the resource specifications that can be modified for a container group, including CPU, memory, GPU classes, and storage allocations.
 
-        :param cpu: The number of CPU cores to allocate to the container (between 1 and 16 cores)., defaults to None
+        :param cpu: The number of CPU cores to allocate to the container (between 1 and 1024 cores)., defaults to None
         :type cpu: int, optional
-        :param memory: The amount of memory to allocate to the container in megabytes (between 1024MB and 61440MB)., defaults to None
+        :param memory: The amount of memory to allocate to the container in megabytes (between 1024MB and 1073741824MB)., defaults to None
         :type memory: int, optional
         :param gpu_classes: List of GPU class identifiers that the container can use, specified as UUIDs., defaults to None
         :type gpu_classes: List[str], optional
-        :param storage_amount: The amount of storage to allocate to the container in bytes (between 1GB and 250GB)., defaults to None
+        :param storage_amount: The amount of storage to allocate to the container in bytes (between 1 GB and 1 PB (1125899906842624 bytes))., defaults to None
         :type storage_amount: int, optional
         :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
         :type shm_size: int, optional
         """
         if cpu is not SENTINEL:
-            self.cpu = self._define_number("cpu", cpu, nullable=True, ge=1, le=16)
+            self.cpu = self._define_number("cpu", cpu, nullable=True, ge=1, le=1024)
         if memory is not SENTINEL:
             self.memory = self._define_number(
-                "memory", memory, nullable=True, ge=1024, le=61440
+                "memory", memory, nullable=True, ge=1024, le=1073741824
             )
         if gpu_classes is not SENTINEL:
             self.gpu_classes = gpu_classes
@@ -57,7 +57,7 @@ class ContainerResourceUpdateSchema(BaseModel):
                 storage_amount,
                 nullable=True,
                 ge=1073741824,
-                le=268435456000,
+                le=1125899906842624,
             )
         if shm_size is not SENTINEL:
             self.shm_size = self._define_number(

--- a/src/salad_cloud_sdk/models/create_container_resource_requirements.py
+++ b/src/salad_cloud_sdk/models/create_container_resource_requirements.py
@@ -8,13 +8,13 @@ from .utils.sentinel import SENTINEL
 class CreateContainerResourceRequirements(BaseModel):
     """Specifies the resource requirements for creating a container.
 
-    :param cpu: The number of CPU cores required by the container. Must be between 1 and 16.
+    :param cpu: The number of CPU cores required by the container. Must be between 1 and 1024.
     :type cpu: int
-    :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.
+    :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.
     :type memory: int
     :param gpu_classes: A list of GPU class UUIDs required by the container. Can be null if no GPU is required., defaults to None
     :type gpu_classes: List[str], optional
-    :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes)., defaults to None
+    :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes)., defaults to None
     :type storage_amount: int, optional
     :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
     :type shm_size: int, optional
@@ -31,24 +31,27 @@ class CreateContainerResourceRequirements(BaseModel):
     ):
         """Specifies the resource requirements for creating a container.
 
-        :param cpu: The number of CPU cores required by the container. Must be between 1 and 16.
+        :param cpu: The number of CPU cores required by the container. Must be between 1 and 1024.
         :type cpu: int
-        :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 61440 MB.
+        :param memory: The amount of memory (in MB) required by the container. Must be between 1024 MB and 1073741824 MB.
         :type memory: int
         :param gpu_classes: A list of GPU class UUIDs required by the container. Can be null if no GPU is required., defaults to None
         :type gpu_classes: List[str], optional
-        :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 250 GB (268435456000 bytes)., defaults to None
+        :param storage_amount: The amount of storage (in bytes) required by the container. Must be between 1 GB (1073741824 bytes) and 1 PB (1125899906842624 bytes)., defaults to None
         :type storage_amount: int, optional
         :param shm_size: The size of the shared memory (/dev/shm) in MB. If not specified, defaults to 64MB., defaults to None
         :type shm_size: int, optional
         """
-        self.cpu = self._define_number("cpu", cpu, ge=1, le=16)
-        self.memory = self._define_number("memory", memory, ge=1024, le=61440)
+        self.cpu = self._define_number("cpu", cpu, ge=1, le=1024)
+        self.memory = self._define_number("memory", memory, ge=1024, le=1073741824)
         if gpu_classes is not SENTINEL:
             self.gpu_classes = gpu_classes
         if storage_amount is not SENTINEL:
             self.storage_amount = self._define_number(
-                "storage_amount", storage_amount, ge=1073741824, le=268435456000
+                "storage_amount",
+                storage_amount,
+                ge=1073741824,
+                le=1125899906842624,
             )
         if shm_size is not SENTINEL:
             self.shm_size = self._define_number(

--- a/src/salad_cloud_sdk/models/system_log.py
+++ b/src/salad_cloud_sdk/models/system_log.py
@@ -71,18 +71,18 @@ class SystemLog(BaseModel):
         if machine_id is not SENTINEL:
             self.machine_id = machine_id
         self.resource_cpu = self._define_number(
-            "resource_cpu", resource_cpu, nullable=True, ge=1, le=16
+            "resource_cpu", resource_cpu, nullable=True, ge=1, le=1024
         )
         self.resource_gpu_class = resource_gpu_class
         self.resource_memory = self._define_number(
-            "resource_memory", resource_memory, nullable=True, ge=1024, le=61440
+            "resource_memory", resource_memory, nullable=True, ge=1024, le=1073741824
         )
         self.resource_storage_amount = self._define_number(
             "resource_storage_amount",
             resource_storage_amount,
             nullable=True,
             ge=1073741824,
-            le=268435456000,
+            le=1125899906842624,
         )
         self.version = version
         self._kwargs = kwargs


### PR DESCRIPTION
This pull request increases the maximum allowed resources for containers across both documentation and SDK model definitions. The main changes are raising the upper limits for CPU cores, memory, and storage, enabling support for much larger resource allocations.

**Resource limit increases:**

* Maximum CPU cores for containers increased from 16 to 1024 in documentation and SDK models (
* Maximum storage amount increased from 250 GB (268,435,456,000 bytes) to 1 PB (1,125,899,906,842,624 bytes)

**Documentation updates:**

* All relevant markdown files have been updated to reflect the new resource limits for CPU, memory, and storage. 

**SDK model updates:**

* All relevant SDK model classes and their constructors have been updated to enforce the new resource limits for validation. 